### PR TITLE
Add janitor-bot to projects list

### DIFF
--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -10,6 +10,12 @@ const page = 'projects';
 
 const projects = [
   {
+    title: 'janitor-bot',
+    date: '2026-04-28',
+    url: 'https://janitor-bot.exe.xyz',
+    external: true,
+  },
+  {
     title: 'Emily for Elkhorn',
     date: '2026-01-31',
     url: 'https://emilyforelkhorn.com',


### PR DESCRIPTION
## Summary
- Adds janitor-bot to the projects index, dated 2026-04-28, linking to https://janitor-bot.exe.xyz

## Test plan
- [x] `pnpm build` succeeds
- [x] `/projects/` renders the new entry at the top of 2026
- [x] External link icon appears next to the title