### PR TITLE
fix(projects): twin-predictions dashboard collapses to a narrow column on desktop

### DIFF
--- a/src/pages/projects/twin-predictions.astro
+++ b/src/pages/projects/twin-predictions.astro
@@ -38,8 +38,28 @@ const leaderboard = revealed ? (leaderboardEntry?.default ?? null) : null;
   <DocumentHead title={title} description={description} permalink={permalink} />
   <body>
     <Layout page={page}>
-      <Dashboard ballots={ballots} client:load />
-      {leaderboard && <Leaderboard data={leaderboard} />}
+      <div class="tp-embed">
+        <Dashboard ballots={ballots} client:load />
+      </div>
+      {
+        leaderboard && (
+          <div class="tp-embed">
+            <Leaderboard data={leaderboard} />
+          </div>
+        )
+      }
     </Layout>
   </body>
 </html>
+
+<style>
+  /*
+   * The Dashboard is a `client:load` island; its generated <astro-island> wrapper is an
+   * inline custom element and, as a direct grid item of `main.breakout`, shrink-wraps to
+   * its content instead of filling the content column. Wrapping it in a block `.tp-embed`
+   * div (the grid item) that stretches full-width fixes the desktop collapse.
+   */
+  .tp-embed {
+    width: 100%;
+  }
+</style>


### PR DESCRIPTION
Follow-up to #95.

## Problem
On desktop, the whole dashboard shrink-wrapped into a ~360px column pinned to the left with a wall of empty space, instead of filling the content column.

## Cause
`Dashboard` is a `client:load` island, so its direct child in `main.breakout` is the generated `<astro-island>` — an inline custom element. As a direct grid item of the `.breakout` named-column grid it shrink-wraps to its content instead of filling the `content` track. There's no global `astro-island { display: block }` in the site.

## Fix
Wrap the island (and the leaderboard, for consistency) in a block `.tp-embed` div so a normal block element is the grid item and stretches to the content column. One scoped style, `.tp-embed { width: 100% }`. No change to the shared layout or other pages.

## Verified
Browser screenshots of the built site (astro preview) at 1440×900 and 390×844: dashboard fills the content column on desktop and stacks cleanly on mobile. `pnpm build` clean.